### PR TITLE
Commit for README.md file -  

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ end
 - It should appear above the tab key, 
 - but it may vary based on your keyboard layout.
 
-<img src="assets/backtick-key.jpg" alt="Image Alt Text" width="300px" />
+<img src="assets/backtick-key.jpg" alt="Backtick key" width="200px" />
 
 
 Good Cloud Engineers use codeblocks for both Code and Errors that appear in the console.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ end
 - It should appear above the tab key, 
 - but it may vary based on your keyboard layout.
 
-<img width="200px" src="[Photo of the pipe character on our keyboard](assets/pipe-char.jpg)" />
+![back tick key](assets/backtick-key.jpg){width=250px}
 
 Good Cloud Engineers use codeblocks for both Code and Errors that appear in the console.
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ end
 - It should appear above the tab key, 
 - but it may vary based on your keyboard layout.
 
-<img width="200px" src="backtick-key.jpg" />
+<img width="200px" src="[backtick-key.jpg](https://github.com/stevejohnutd/github-docs-example/blob/main/assets/backtick-key.jpg)" />
 
 Good Cloud Engineers use codeblocks for both Code and Errors that appear in the console.
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ end
 - It should appear above the tab key, 
 - but it may vary based on your keyboard layout.
 
-![back tick key](assets/backtick-key.jpg){width=250px}
+<img src="assets/backtick-key.jpg" alt="Image Alt Text" width="300px" />
+
 
 Good Cloud Engineers use codeblocks for both Code and Errors that appear in the console.
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ This is what a screenshot from your computer should look like
 
 **DO THIS INSTEAD**
 
-![Screenshot example](screenshot-example.png)
+![Screenshot example](assets/screenshot-example.png)
 
 To take screenshots on both macOS and Windows, you can use the following hotkeys:
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ end
 - It should appear above the tab key, 
 - but it may vary based on your keyboard layout.
 
-<img width="200px" src="[backtick-key.jpg](https://github.com/stevejohnutd/github-docs-example/blob/main/assets/backtick-key.jpg)" />
+<img width="200px" src="[Photo of the pipe character on our keyboard](assets/pipe-char.jpg)" />
 
 Good Cloud Engineers use codeblocks for both Code and Errors that appear in the console.
 


### PR DESCRIPTION
Updating paths for two pictures in the document. 

**Context:** I was going through "Github Markdown Editor and Github Flavoured Markdown (GFM)" training video and identified why 2 pictures weren't being displayed in README.md file. 